### PR TITLE
Removed unused parameters from kinematics and socket config files

### DIFF
--- a/configs/kinematics/kinematics.yaml
+++ b/configs/kinematics/kinematics.yaml
@@ -1,43 +1,43 @@
 /**:
-    ros__parameters:
-        num_wheels: 4
-        control_rate: 100.0
-        wheel_radius: 0.090
-        wheel_lever_arm: 0.045
-        zero_vel_threshold: 0.001
-        small_vel_threshold: 0.02
-        steer_hysteresis: 30.0
-        broadcast_tf: true
-        cmd_timeout: 0.2
+  ros__parameters:
+    num_wheels: 4
+    control_rate: 100.0
+    wheel_radius: 0.090
+    wheel_lever_arm: 0.045
+    zero_vel_threshold: 0.001
+    small_vel_threshold: 0.02
+    steer_hysteresis: 30.0
+    broadcast_tf: true
+    cmd_timeout: 0.2
 
-        drive0:
-            joint_name: mpo_700_wheel_front_left_joint
-        steer0:
-            joint_name: mpo_700_caster_front_left_joint
-            center_pos_x: 0.240
-            center_pos_y: 0.190
-            home_angle: 180.0
+    drive0:
+      joint_name: mpo_700_wheel_front_left_joint
+    steer0:
+      joint_name: mpo_700_caster_front_left_joint
+      center_pos_x: 0.240
+      center_pos_y: 0.190
+      home_angle: 180.0
 
-        drive1:
-            joint_name: mpo_700_wheel_back_left_joint
-        steer1:
-            joint_name: mpo_700_caster_back_left_joint
-            center_pos_x: -0.240
-            center_pos_y: 0.190
-            home_angle: 180.0
+    drive1:
+      joint_name: mpo_700_wheel_back_left_joint
+    steer1:
+      joint_name: mpo_700_caster_back_left_joint
+      center_pos_x: -0.240
+      center_pos_y: 0.190
+      home_angle: 180.0
 
-        drive2:
-            joint_name: mpo_700_wheel_back_right_joint
-        steer2:
-            joint_name: mpo_700_caster_back_right_joint
-            center_pos_x: -0.240
-            center_pos_y: -0.190
-            home_angle: 0.0
+    drive2:
+      joint_name: mpo_700_wheel_back_right_joint
+    steer2:
+      joint_name: mpo_700_caster_back_right_joint
+      center_pos_x: -0.240
+      center_pos_y: -0.190
+      home_angle: 0.0
 
-        drive3:
-            joint_name: mpo_700_wheel_front_right_joint
-        steer3:
-            joint_name: mpo_700_caster_front_right_joint
-            center_pos_x: 0.240
-            center_pos_y: -0.190
-            home_angle: 0.0
+    drive3:
+      joint_name: mpo_700_wheel_front_right_joint
+    steer3:
+      joint_name: mpo_700_caster_front_right_joint
+      center_pos_x: 0.240
+      center_pos_y: -0.190
+      home_angle: 0.0

--- a/configs/kinematics/kinematics.yaml
+++ b/configs/kinematics/kinematics.yaml
@@ -1,93 +1,43 @@
 /**:
-  ros__parameters:
-    num_wheels: 4
-    control_rate: 100.0
-    wheel_radius: 0.090
-    wheel_lever_arm: 0.045
-    zero_vel_threshold: 0.001
-    small_vel_threshold: 0.02
-    steer_hysteresis: 30.0
-    steer_gain: 10.0
-    steer_lookahead: 0.06
-    steer_low_pass: 0.5
-    max_steer_vel: 8.0
-    motor_delay: 0.0
-    broadcast_tf: true
+    ros__parameters:
+        num_wheels: 4
+        control_rate: 100.0
+        wheel_radius: 0.090
+        wheel_lever_arm: 0.045
+        zero_vel_threshold: 0.001
+        small_vel_threshold: 0.02
+        steer_hysteresis: 30.0
+        broadcast_tf: true
+        cmd_timeout: 0.2
 
-    can_iface: can0
-    motor_timeout: 0.2
-    cmd_timeout: 0.2
-    trajectory_timeout: 0.1
-    home_vel: -1.0
+        drive0:
+            joint_name: mpo_700_wheel_front_left_joint
+        steer0:
+            joint_name: mpo_700_caster_front_left_joint
+            center_pos_x: 0.240
+            center_pos_y: 0.190
+            home_angle: 180.0
 
-    drive0:
-      can_id: 2
-      joint_name: mpo_700_wheel_front_left_joint
-      rot_sign: -1
-      gear_ratio: 30.0
-      enc_ticks_per_rev: 10000.0
-    steer0:
-      can_id: 1
-      joint_name: mpo_700_caster_front_left_joint
-      center_pos_x: 0.240
-      center_pos_y: 0.190
-      rot_sign: 1
-      gear_ratio: 19
-      enc_ticks_per_rev: 10000
-      home_angle: 180.0
-      home_dig_in: 9
-      enc_home_offset: 4509
+        drive1:
+            joint_name: mpo_700_wheel_back_left_joint
+        steer1:
+            joint_name: mpo_700_caster_back_left_joint
+            center_pos_x: -0.240
+            center_pos_y: 0.190
+            home_angle: 180.0
 
-    drive1:
-      can_id: 4
-      joint_name: mpo_700_wheel_back_left_joint
-      rot_sign: 1
-      gear_ratio: 30
-      enc_ticks_per_rev: 10000
-    steer1:
-      can_id: 3
-      joint_name: mpo_700_caster_back_left_joint
-      center_pos_x: -0.240
-      center_pos_y: 0.190
-      rot_sign: -1
-      gear_ratio: 19
-      enc_ticks_per_rev: 10000
-      home_angle: 180.0
-      home_dig_in: 9
-      enc_home_offset: -4278
+        drive2:
+            joint_name: mpo_700_wheel_back_right_joint
+        steer2:
+            joint_name: mpo_700_caster_back_right_joint
+            center_pos_x: -0.240
+            center_pos_y: -0.190
+            home_angle: 0.0
 
-    drive2:
-      can_id: 6
-      joint_name: mpo_700_wheel_back_right_joint
-      rot_sign: -1
-      gear_ratio: 30
-      enc_ticks_per_rev: 10000
-    steer2:
-      can_id: 5
-      joint_name: mpo_700_caster_back_right_joint
-      center_pos_x: -0.240
-      center_pos_y: -0.190
-      rot_sign: 1
-      gear_ratio: 19
-      enc_ticks_per_rev: 10000
-      home_angle: 0.0
-      home_dig_in: 9
-      enc_home_offset: 4705
-
-    drive3:
-      can_id: 8
-      joint_name: mpo_700_wheel_front_right_joint
-      rot_sign: 1
-      gear_ratio: 30
-      enc_ticks_per_rev: 10000
-    steer3:
-      can_id: 7
-      joint_name: mpo_700_caster_front_right_joint
-      center_pos_x: 0.240
-      center_pos_y: -0.190
-      rot_sign: -1
-      gear_ratio: 19
-      enc_ticks_per_rev: 10000
-      home_angle: 0.0
-      home_dig_in: 9
-      enc_home_offset: -4240
+        drive3:
+            joint_name: mpo_700_wheel_front_right_joint
+        steer3:
+            joint_name: mpo_700_caster_front_right_joint
+            center_pos_x: 0.240
+            center_pos_y: -0.190
+            home_angle: 0.0

--- a/configs/kinematics/socket.yaml
+++ b/configs/kinematics/socket.yaml
@@ -1,83 +1,83 @@
 /**:
-    ros__parameters:
-        num_wheels: 4
-        control_rate: 100.0
-        request_status_divider: 10
-        heartbeat_divider: 5
-        steer_gain: 10.0
-        steer_lookahead: 0.06
-        steer_low_pass: 0.5
-        max_steer_vel: 8.0
-        motor_delay: 0.0
-        can_iface: can0
-        motor_timeout: 0.2
-        trajectory_timeout: 0.1
-        home_vel: -1.0
-        drive_low_pass: 0.5
-        auto_home: true
-        motor_group_id: 30
-        measure_torque: false
+  ros__parameters:
+    num_wheels: 4
+    control_rate: 100.0
+    request_status_divider: 10
+    heartbeat_divider: 5
+    steer_gain: 10.0
+    steer_lookahead: 0.06
+    steer_low_pass: 0.5
+    max_steer_vel: 8.0
+    motor_delay: 0.0
+    can_iface: can0
+    motor_timeout: 0.2
+    trajectory_timeout: 0.1
+    home_vel: -1.0
+    drive_low_pass: 0.5
+    auto_home: true
+    motor_group_id: 30
+    measure_torque: false
 
-        drive0:
-            can_id: 2
-            joint_name: mpo_700_wheel_front_left_joint
-            rot_sign: -1
-            gear_ratio: 30
-            enc_ticks_per_rev: 10000
-        steer0:
-            can_id: 1
-            joint_name: mpo_700_caster_front_left_joint
-            rot_sign: 1
-            gear_ratio: 19
-            enc_ticks_per_rev: 10000
-            home_angle: 180.0
-            home_dig_in: 9
-            enc_home_offset: 4663
+    drive0:
+      can_id: 2
+      joint_name: mpo_700_wheel_front_left_joint
+      rot_sign: -1
+      gear_ratio: 30
+      enc_ticks_per_rev: 10000
+    steer0:
+      can_id: 1
+      joint_name: mpo_700_caster_front_left_joint
+      rot_sign: 1
+      gear_ratio: 19
+      enc_ticks_per_rev: 10000
+      home_angle: 180.0
+      home_dig_in: 9
+      enc_home_offset: 4663
 
-        drive1:
-            can_id: 4
-            joint_name: mpo_700_wheel_back_left_joint
-            rot_sign: 1
-            gear_ratio: 30
-            enc_ticks_per_rev: 10000
-        steer1:
-            can_id: 3
-            joint_name: mpo_700_caster_back_left_joint
-            rot_sign: -1
-            gear_ratio: 19
-            enc_ticks_per_rev: 10000
-            home_angle: 180.0
-            home_dig_in: 9
-            enc_home_offset: -5429
+    drive1:
+      can_id: 4
+      joint_name: mpo_700_wheel_back_left_joint
+      rot_sign: 1
+      gear_ratio: 30
+      enc_ticks_per_rev: 10000
+    steer1:
+      can_id: 3
+      joint_name: mpo_700_caster_back_left_joint
+      rot_sign: -1
+      gear_ratio: 19
+      enc_ticks_per_rev: 10000
+      home_angle: 180.0
+      home_dig_in: 9
+      enc_home_offset: -5429
 
-        drive2:
-            can_id: 6
-            joint_name: mpo_700_wheel_back_right_joint
-            rot_sign: -1
-            gear_ratio: 30
-            enc_ticks_per_rev: 10000
-        steer2:
-            can_id: 5
-            joint_name: mpo_700_caster_back_right_joint
-            rot_sign: 1
-            gear_ratio: 19
-            enc_ticks_per_rev: 10000
-            home_angle: 0.0
-            home_dig_in: 9
-            enc_home_offset: 4845
+    drive2:
+      can_id: 6
+      joint_name: mpo_700_wheel_back_right_joint
+      rot_sign: -1
+      gear_ratio: 30
+      enc_ticks_per_rev: 10000
+    steer2:
+      can_id: 5
+      joint_name: mpo_700_caster_back_right_joint
+      rot_sign: 1
+      gear_ratio: 19
+      enc_ticks_per_rev: 10000
+      home_angle: 0.0
+      home_dig_in: 9
+      enc_home_offset: 4845
 
-        drive3:
-            can_id: 8
-            joint_name: mpo_700_wheel_front_right_joint
-            rot_sign: 1
-            gear_ratio: 30
-            enc_ticks_per_rev: 10000
-        steer3:
-            can_id: 7
-            joint_name: mpo_700_caster_front_right_joint
-            rot_sign: -1
-            gear_ratio: 19
-            enc_ticks_per_rev: 10000
-            home_angle: 0.0
-            home_dig_in: 9
-            enc_home_offset: -5363
+    drive3:
+      can_id: 8
+      joint_name: mpo_700_wheel_front_right_joint
+      rot_sign: 1
+      gear_ratio: 30
+      enc_ticks_per_rev: 10000
+    steer3:
+      can_id: 7
+      joint_name: mpo_700_caster_front_right_joint
+      rot_sign: -1
+      gear_ratio: 19
+      enc_ticks_per_rev: 10000
+      home_angle: 0.0
+      home_dig_in: 9
+      enc_home_offset: -5363

--- a/configs/kinematics/socket.yaml
+++ b/configs/kinematics/socket.yaml
@@ -1,100 +1,83 @@
 /**:
-  ros__parameters:
-    num_wheels: 4
-    control_rate: 100.0
-    wheel_radius: 0.090
-    wheel_lever_arm: 0.045
-    zero_vel_threshold: 0.001
-    request_status_divider: 10
-    heartbeat_divider: 5
-    small_vel_threshold: 0.02
-    steer_hysteresis: 30
-    steer_hysteresis_dynamic: 5
-    steer_gain: 10.0
-    steer_lookahead: 0.06
-    steer_low_pass: 0.5
-    max_steer_vel: 8.0
-    motor_delay: 0.0
-    broadcast_tf: true
-    can_iface: can0
-    motor_timeout: 0.2
-    cmd_timeout: 0.2
-    trajectory_timeout: 0.1
-    home_vel: -1.0
-    drive_low_pass: 0.5
-    auto_home: true
-    motor_group_id: 30
-    steer_reset_button: 1
-    measure_torque: false
+    ros__parameters:
+        num_wheels: 4
+        control_rate: 100.0
+        request_status_divider: 10
+        heartbeat_divider: 5
+        steer_gain: 10.0
+        steer_lookahead: 0.06
+        steer_low_pass: 0.5
+        max_steer_vel: 8.0
+        motor_delay: 0.0
+        can_iface: can0
+        motor_timeout: 0.2
+        trajectory_timeout: 0.1
+        home_vel: -1.0
+        drive_low_pass: 0.5
+        auto_home: true
+        motor_group_id: 30
+        measure_torque: false
 
-    drive0:
-      can_id: 2
-      joint_name: mpo_700_wheel_front_left_joint
-      rot_sign: -1
-      gear_ratio: 30
-      enc_ticks_per_rev: 10000
-    steer0:
-      can_id: 1
-      joint_name: mpo_700_caster_front_left_joint
-      center_pos_x: 0.240
-      center_pos_y: 0.190
-      rot_sign: 1
-      gear_ratio: 19
-      enc_ticks_per_rev: 10000
-      home_angle: 180.0
-      home_dig_in: 9
-      enc_home_offset: 4663
+        drive0:
+            can_id: 2
+            joint_name: mpo_700_wheel_front_left_joint
+            rot_sign: -1
+            gear_ratio: 30
+            enc_ticks_per_rev: 10000
+        steer0:
+            can_id: 1
+            joint_name: mpo_700_caster_front_left_joint
+            rot_sign: 1
+            gear_ratio: 19
+            enc_ticks_per_rev: 10000
+            home_angle: 180.0
+            home_dig_in: 9
+            enc_home_offset: 4663
 
-    drive1:
-      can_id: 4
-      joint_name: mpo_700_wheel_back_left_joint
-      rot_sign: 1
-      gear_ratio: 30
-      enc_ticks_per_rev: 10000
-    steer1:
-      can_id: 3
-      joint_name: mpo_700_caster_back_left_joint
-      center_pos_x: -0.240
-      center_pos_y: 0.190
-      rot_sign: -1
-      gear_ratio: 19
-      enc_ticks_per_rev: 10000
-      home_angle: 180.0
-      home_dig_in: 9
-      enc_home_offset: -5429
+        drive1:
+            can_id: 4
+            joint_name: mpo_700_wheel_back_left_joint
+            rot_sign: 1
+            gear_ratio: 30
+            enc_ticks_per_rev: 10000
+        steer1:
+            can_id: 3
+            joint_name: mpo_700_caster_back_left_joint
+            rot_sign: -1
+            gear_ratio: 19
+            enc_ticks_per_rev: 10000
+            home_angle: 180.0
+            home_dig_in: 9
+            enc_home_offset: -5429
 
-    drive2:
-      can_id: 6
-      joint_name: mpo_700_wheel_back_right_joint
-      rot_sign: -1
-      gear_ratio: 30
-      enc_ticks_per_rev: 10000
-    steer2:
-      can_id: 5
-      joint_name: mpo_700_caster_back_right_joint
-      center_pos_x: -0.240
-      center_pos_y: -0.190
-      rot_sign: 1
-      gear_ratio: 19
-      enc_ticks_per_rev: 10000
-      home_angle: 0.0
-      home_dig_in: 9
-      enc_home_offset: 4845
+        drive2:
+            can_id: 6
+            joint_name: mpo_700_wheel_back_right_joint
+            rot_sign: -1
+            gear_ratio: 30
+            enc_ticks_per_rev: 10000
+        steer2:
+            can_id: 5
+            joint_name: mpo_700_caster_back_right_joint
+            rot_sign: 1
+            gear_ratio: 19
+            enc_ticks_per_rev: 10000
+            home_angle: 0.0
+            home_dig_in: 9
+            enc_home_offset: 4845
 
-    drive3:
-      can_id: 8
-      joint_name: mpo_700_wheel_front_right_joint
-      rot_sign: 1
-      gear_ratio: 30
-      enc_ticks_per_rev: 10000
-    steer3:
-      can_id: 7
-      joint_name: mpo_700_caster_front_right_joint
-      center_pos_x: 0.240
-      center_pos_y: -0.190
-      rot_sign: -1
-      gear_ratio: 19
-      enc_ticks_per_rev: 10000
-      home_angle: 0.0
-      home_dig_in: 9
-      enc_home_offset: -5363
+        drive3:
+            can_id: 8
+            joint_name: mpo_700_wheel_front_right_joint
+            rot_sign: 1
+            gear_ratio: 30
+            enc_ticks_per_rev: 10000
+        steer3:
+            can_id: 7
+            joint_name: mpo_700_caster_front_right_joint
+            rot_sign: -1
+            gear_ratio: 19
+            enc_ticks_per_rev: 10000
+            home_angle: 0.0
+            home_dig_in: 9
+            enc_home_offset: -5363


### PR DESCRIPTION
Removed some of the parameters from both `kinematics.yaml` and `socket.yaml` files, that were not used by the `neo_omnidrive_node.cpp` and `neo_omnidrive_socketcan.cpp` nodes in `neo_kinematics_omnidrive2` respectively.