### PR TITLE
Added support for ur arm dc cabinet

### DIFF
--- a/launch/bringup.launch.py
+++ b/launch/bringup.launch.py
@@ -29,6 +29,7 @@ def execution_stage(context: LaunchContext,
                     disable_scanners,
                     docking_adapter,
                     arm_type,
+                    ur_dc,
                     gripper_type,
                     mock_arm,
                     robot_ip,
@@ -40,6 +41,7 @@ def execution_stage(context: LaunchContext,
     d435_enabl = str(d435_enable.perform(context))
     scanner_typ = str(scanner_type.perform(context))
     arm_typ = str(arm_type.perform(context))
+    use_ur_dc = str(ur_dc.perform(context))
     gripper_typ = str(gripper_type.perform(context))
     use_docking_adapter = str(docking_adapter.perform(context))
     use_mock = str(mock_arm.perform(context))
@@ -59,6 +61,7 @@ def execution_stage(context: LaunchContext,
     xacro_args = [
         "xacro", " ", urdf,
         " ", 'arm_type:=', arm_typ,
+        " ", 'use_ur_dc:=', use_ur_dc,
         " ", 'robot_ip:=', robot_ip,
         " ", 'gripper_type:=', gripper_typ,
         " ", 'use_mock_hardware:=', use_mock,
@@ -328,6 +331,11 @@ def generate_launch_description():
             description='Arm Types\n\t'
         )
 
+    declare_ur_pwr_variant_cmd = DeclareLaunchArgument(
+            'use_ur_dc', default_value='False',
+            description='Set this argument to True if you have an UR arm with DC variant'
+        )
+
     declare_robotiq_cmd = DeclareLaunchArgument(
             'gripper_type', default_value='',
             choices=['', '2f_140', '2f_85', 'epick'],
@@ -363,6 +371,7 @@ def generate_launch_description():
             LaunchConfiguration('disable_scanners'),
             LaunchConfiguration('use_docking_adapter'),
             LaunchConfiguration('arm_type'),
+            LaunchConfiguration('use_ur_dc'),
             LaunchConfiguration('gripper_type'),
             LaunchConfiguration('use_mock_arm'),
             LaunchConfiguration('robot_ip'),
@@ -377,6 +386,7 @@ def generate_launch_description():
         declare_disable_scanner_type_cmd,
         declare_use_docking_adapter_cmd,
         declare_arm_type_cmd,
+        declare_ur_pwr_variant_cmd,
         declare_robotiq_cmd,
         declare_mock_arm_cmd,
         declare_robot_ip_cmd,

--- a/launch/bringup_sim.launch.py
+++ b/launch/bringup_sim.launch.py
@@ -18,6 +18,7 @@ def execution_stage(context: LaunchContext,
                     robot_namespace,
                     world,
                     arm_type,
+                    ur_dc,
                     imu_enable,
                     d435_enable,
                     scanner_type,
@@ -39,6 +40,7 @@ def execution_stage(context: LaunchContext,
             'robot_type': robot_type,
             'world': world_name,
             'arm_type': arm_type,
+            'use_ur_dc': ur_dc,
             'imu_enable': imu_enable,
             'd435_enable': d435_enable,
             'scanner_type': scanner_type,
@@ -70,6 +72,11 @@ def generate_launch_description():
             'arm_type', default_value='',
             choices=['', 'ur5', 'ur10', 'ur5e', 'ur10e', 'ec66', 'cs66'],
             description='Arm Types\n\t'
+        )
+
+    declare_ur_pwr_variant_cmd = DeclareLaunchArgument(
+            'use_ur_dc', default_value='False',
+            description='Set this argument to True if you have an UR arm with DC variant'
         )
 
     declare_imu_cmd = DeclareLaunchArgument(
@@ -105,6 +112,7 @@ def generate_launch_description():
             LaunchConfiguration('robot_namespace'),
             LaunchConfiguration('world'),
             LaunchConfiguration('arm_type'),
+            LaunchConfiguration('use_ur_dc'),
             LaunchConfiguration('imu_enable'),
             LaunchConfiguration('d435_enable'),
             LaunchConfiguration('scanner_type'),
@@ -116,6 +124,7 @@ def generate_launch_description():
         declare_namespace_cmd,
         declare_world_name_arg,
         declare_arm_type_cmd,
+        declare_ur_pwr_variant_cmd,
         declare_imu_cmd,
         declare_realsense_cmd,
         declare_scanner_type_cmd,

--- a/launch/rviz.launch.py
+++ b/launch/rviz.launch.py
@@ -29,6 +29,7 @@ def execution_stage(context: LaunchContext,
                     gripper_type,
                     docking_adapter,
                     display_mode,
+                    ur_dc,
                     rviz_config):
 
     launch_actions = []
@@ -37,6 +38,7 @@ def execution_stage(context: LaunchContext,
 
     # Resolve launch arguments
     arm_typ = str(arm_type.perform(context))
+    use_ur_dc = ur_dc.perform(context)
     imu_enabl = str(imu_enable.perform(context))
     d435_enabl = str(d435_enable.perform(context))
     scanner_typ = str(scanner_type.perform(context))
@@ -56,6 +58,7 @@ def execution_stage(context: LaunchContext,
         "xacro", " ", urdf,
         " ", 'use_gz:=true',
         " ", 'arm_type:=', arm_typ,
+        " ", 'use_ur_dc:=', use_ur_dc,
         " ", 'force_abs_path:=true',
         " ", 'gripper_type:=', gripper_typ,
         " ", 'use_imu:=', imu_enabl,
@@ -134,6 +137,11 @@ def generate_launch_description():
             description='Disable robot and joint state publishers if true (True/False)'
         )
 
+    declare_ur_pwr_variant_cmd = DeclareLaunchArgument(
+            'use_ur_dc', default_value='False',
+            description='Set this argument to True if you have an UR arm with DC variant'
+        )
+
     declare_rviz_cfg_arg = DeclareLaunchArgument(
             'rviz_config',
             default_value=os.path.join(
@@ -154,6 +162,7 @@ def generate_launch_description():
             LaunchConfiguration('gripper_type'),
             LaunchConfiguration('use_docking_adapter'),
             LaunchConfiguration('display_mode'),
+            LaunchConfiguration('use_ur_dc'),
             LaunchConfiguration('rviz_config')
         ])
 
@@ -167,6 +176,7 @@ def generate_launch_description():
         declare_gripper_type_cmd,
         declare_use_docking_adapter_cmd,
         declare_use_display_mode_cmd,
+        declare_ur_pwr_variant_cmd,
         declare_rviz_cfg_arg,
         opq_function
     ])

--- a/robot_model/mpo_700.urdf.xacro
+++ b/robot_model/mpo_700.urdf.xacro
@@ -18,6 +18,7 @@ Contributor: Adarsh Karan K P
   <xacro:arg name="arm_type" default=""/>
   <xacro:arg name="arm_parent" default="cabinet_link"/>
   <xacro:arg name="gripper_type" default=""/>
+  <xacro:arg name="use_ur_dc" default="false"/>
   <xacro:arg name="force_abs_paths" default="false"/>
   <xacro:arg name="simulation_controllers" default=""/>
   <xacro:arg name="use_mock_hardware" default="false"/>
@@ -35,6 +36,7 @@ Contributor: Adarsh Karan K P
   <xacro:property name="disable_scanner" value="$(arg disable_scanners)"/>
   <xacro:property name="scanner_height" value="0"/>
   <xacro:property name="gripper" value="$(arg gripper_type)"/>
+  <xacro:property name="ur_dc" value="$(arg use_ur_dc)"/>
   <xacro:property name="docking_adapter" value="$(arg use_docking_adapter)"/>
   <xacro:property name="use_mock" value="$(arg use_mock_hardware)"/>
   
@@ -135,11 +137,23 @@ Contributor: Adarsh Karan K P
 
     <!-- Universal Robotics (UR) Arms-->
     <xacro:if value="${arm == 'ur5' or arm == 'ur10' or arm == 'ur5e' or arm == 'ur10e'}">
+      
+      <!-- Different height for AC arm-->
+      <xacro:if value="${ur_dc == False}">
+        <xacro:property name="arm_height" value="0.416" />
+      </xacro:if>
+
+      <xacro:if value="${ur_dc == True}">
+        <xacro:property name="arm_height" value="0.307" />
+      </xacro:if>
+
+      <!-- Include the UR arm -->
       <xacro:include filename="$(find mp_components)/urdf/arm/ur_arm.urdf.xacro"/>
     </xacro:if>
 
     <!-- Elite Arms-->
     <xacro:if value="${arm == 'ec66' or arm == 'cs66'}">
+      <xacro:property name="arm_height" value="0.376" />
       <xacro:include filename="$(find mp_components)/urdf/arm/elite_arm.urdf.xacro"/>
     </xacro:if>
 


### PR DESCRIPTION
- Addresses #68 
- Modified bringup_sim, bringup and rviz launch files to support ur dc cabinet
- modified mpo_700 urdf to support the same

Commands used to test

Simulation
```
ros2 launch neo_mpo_700-2 bringup_sim.launch.py arm_type:=ur10 use_ur_dc:=True gripper_type:=2f_85
```

Mock HW
```
ros2 launch neo_mpo_700-2 bringup.launch.py use_mock_arm:=True arm_type:=ur10 use_ur_dc:=True gripper_type:=2f_85 use_mock_arm:=True
```

Rviz display
```
ros2 launch neo_mpo_700-2 rviz.launch.py display_mode:=False arm_type:=ur10 use_ur_dc:=True
```

Moveit with mock hardware
```
ros2 launch neo_ur_moveit_config neo_ur_moveit.launch.py robot_type:=mpo_700 arm_type:=ur10 prefix:=ur10 gripper_type:=2f_85 use_mock_hardware:=True use_ur_dc:=True
```

Moveit with simulation
```
ros2 launch neo_ur_moveit_config neo_ur_moveit.launch.py robot_type:=mpo_700 arm_type:=ur10 prefix:=ur10 gripper_type:=2f_85 use_gz:=True use_ur_dc:=True

```